### PR TITLE
Integration CI with nuclio

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python_version: [ 3.6, 3.7, 3.8, 3.9 ]
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
@@ -32,15 +32,15 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python_version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          make install_pipenv PIPENV_PYTHON_VERSION=${{ matrix.python-version }}
+          make install_pipenv PIPENV_PYTHON_VERSION=${{ matrix.python_version }}
 
       - name: Lint
         run: make lint
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ 3.8 ]
+        python_version: [ 3.6, 3.7, 3.8, 3.9 ]
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
@@ -77,6 +77,11 @@ jobs:
           path: nuclio
           token: ${{ github.token }}
 
+      - name: Set function name
+        run: |
+          function_name=$(echo "sdk-py-func-${{ matrix.python_version }}" |  tr '.' '-')
+          echo "FUNCTION_NAME=$function_name" >> $GITHUB_ENV
+
       - name: Render CI function yaml
         run: |
           cat $(pwd)/hack/ci_assets/function/function.yaml | \
@@ -84,6 +89,7 @@ jobs:
             tee $(pwd)/hack/ci_assets/function/function.yaml
         working-directory: nuclio-sdk-py
         env:
+          FUNCTION_NAME: ${{ env.FUNCTION_NAME }}
           REPO_USER: ${{ github.actor }}
           REPO_BRANCH: ${{ github.head_ref }}
           FUNCTION_RUNTIME: python:${{ matrix.python_version }}
@@ -100,14 +106,14 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Build nuctl
-        run: |
-          CGO_ENABLED=0 \
-            go build -a -installsuffix cgo -ldflags="-s -w -X github.com/v3io/version-go.gitCommit= -X github.com/v3io/version-go.label=unstable -X github.com/v3io/version-go.arch=amd64" -o $GOPATH/bin/nuctl-unstable-linux-amd64 cmd/nuctl/main.go
+        run: make nuctl-bin
         working-directory: nuclio
 
       - name: Install nuctl
         run: |
-          cp $GOPATH/bin/nuctl-$NUCLIO_LABEL-linux-amd64 ./nuctl
+
+          # install nuctl
+          cp nuctl-$NUCLIO_LABEL-linux-amd64 nuctl
           sudo -EH install nuctl /usr/local/bin
 
           # print version for sanity
@@ -116,13 +122,18 @@ jobs:
 
       - name: Deploy function
         run: |
-          nuctl deploy sdk-py-func-${{ matrix.python_version }} \
+          nuctl deploy $FUNCTION_NAME \
             --verbose \
             --path $(pwd)/hack/ci_assets/function \
             --file $(pwd)/hack/ci_assets/function/function.yaml
-
         working-directory: nuclio-sdk-py
+        env:
+          NUCLIO_DASHBOARD_DEFAULT_FUNCTION_MOUNT_MODE: volume
 
       - name: Invoke
         run: |
-          nuctl invoke
+          nuctl invoke $FUNCTION_NAME
+
+      - name: Print function logs
+        run: |
+          docker logs nuclio-nuclio-$FUNCTION_NAME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,23 +1,35 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-      - development
+#  push:
+#    branches:
+#      - master
+#      - development
   pull_request:
     branches:
       - master
       - development
 
+env:
+  NUCLIO_LABEL: unstable
+
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
     steps:
+      - name: Dump github context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Dump runner context
+        run: echo "$RUNNER_CONTEXT"
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -35,3 +47,82 @@ jobs:
 
       - name: Test
         run: make test
+
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: [ 3.8 ]
+    steps:
+      - name: Dump github context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Dump runner context
+        run: echo "$RUNNER_CONTEXT"
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+
+      - name: Clone Nuclio sdk py
+        uses: actions/checkout@v2
+        with:
+          path: nuclio-sdk-py
+
+      - name: Clone Nuclio
+        uses: actions/checkout@v2
+        with:
+          repository: nuclio/nuclio
+          ref: development
+          path: nuclio
+          token: ${{ github.token }}
+
+      - name: Render CI function yaml
+        run: |
+          cat $(pwd)/hack/ci_assets/function/function.yaml | \
+            envsubst | \
+            tee $(pwd)/hack/ci_assets/function/function.yaml
+        working-directory: nuclio-sdk-py
+        env:
+          REPO_USER: ${{ github.actor }}
+          REPO_BRANCH: ${{ github.head_ref }}
+          FUNCTION_RUNTIME: python:${{ matrix.python_version }}
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.14.0"
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/nuclio/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build nuctl
+        run: |
+          CGO_ENABLED=0 \
+            go build -a -installsuffix cgo -ldflags="-s -w -X github.com/v3io/version-go.gitCommit= -X github.com/v3io/version-go.label=unstable -X github.com/v3io/version-go.arch=amd64" -o $GOPATH/bin/nuctl-unstable-linux-amd64 cmd/nuctl/main.go
+        working-directory: nuclio
+
+      - name: Install nuctl
+        run: |
+          cp $GOPATH/bin/nuctl-$NUCLIO_LABEL-linux-amd64 ./nuctl
+          sudo -EH install nuctl /usr/local/bin
+
+          # print version for sanity
+          nuctl version
+        working-directory: nuclio
+
+      - name: Deploy function
+        run: |
+          nuctl deploy sdk-py-func-${{ matrix.python_version }} \
+            --verbose \
+            --path $(pwd)/hack/ci_assets/function \
+            --file $(pwd)/hack/ci_assets/function/function.yaml
+
+        working-directory: nuclio-sdk-py
+
+      - name: Invoke
+        run: |
+          nuctl invoke

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python_version: [ 3.6, 3.7, 3.8 ]
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python_version: [ 3.6, 3.7, 3.8 ]
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: CI
 
 on:
-#  push:
-#    branches:
-#      - master
-#      - development
+  push:
+    branches:
+      - master
+      - development
   pull_request:
     branches:
       - master
@@ -80,7 +80,19 @@ jobs:
       - name: Set function name
         run: |
           function_name=$(echo "sdk-py-func-${{ matrix.python_version }}" |  tr '.' '-')
+
+          # if pull request, else push
+          if [ "${{ github.event_name }}" == "pull_request" ]; then\
+            actor=${{ github.actor }};\
+            branch=${{ github.head_ref }};\
+          else\
+            actor=${{ github.repository_owner }};\
+            branch=${GITHUB_REF#refs/heads/};\
+          fi
+
           echo "FUNCTION_NAME=$function_name" >> $GITHUB_ENV
+          echo "ACTOR=$actor" >> $GITHUB_ENV
+          echo "BRANCH=$branch" >> $GITHUB_ENV
 
       - name: Render CI function yaml
         run: |
@@ -89,9 +101,9 @@ jobs:
             tee $(pwd)/hack/ci_assets/function/function.yaml
         working-directory: nuclio-sdk-py
         env:
+          REPO_USER: ${{ env.ACTOR }}
+          REPO_BRANCH: ${{ env.BRANCH }}
           FUNCTION_NAME: ${{ env.FUNCTION_NAME }}
-          REPO_USER: ${{ github.actor }}
-          REPO_BRANCH: ${{ github.head_ref }}
           FUNCTION_RUNTIME: python:${{ matrix.python_version }}
 
       - uses: actions/setup-go@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 nuclio_sdk.egg-info/
 *.pyc
 .idea
+.github/act

--- a/hack/ci_assets/function/function.yaml
+++ b/hack/ci_assets/function/function.yaml
@@ -1,0 +1,8 @@
+spec:
+  handler: main:handler
+  runtime: $FUNCTION_RUNTIME
+  description: Tests nuclio python sdk for CI
+  build:
+    commands:
+      - "@nuclio.postCopy"
+      - "pip install git+https://github.com/$REPO_USER/nuclio-sdk-py.git@$REPO_BRANCH"

--- a/hack/ci_assets/function/function.yaml
+++ b/hack/ci_assets/function/function.yaml
@@ -1,3 +1,5 @@
+meta:
+  name: $FUNCTION_NAME
 spec:
   handler: main:handler
   runtime: $FUNCTION_RUNTIME

--- a/hack/ci_assets/function/main.py
+++ b/hack/ci_assets/function/main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pkg_resources
 import http
 
 import nuclio_sdk
@@ -20,6 +21,12 @@ import nuclio_sdk
 def handler(context: nuclio_sdk.Context, event: nuclio_sdk.Event):
     context.logger.debug_with("Received request", event=event.to_json())
     return context.Response(headers=event.headers,
-                            body=event.body,
+                            body={
+                                'sdk_version': get_sdk_version(),
+                            },
                             content_type=event.content_type,
                             status_code=http.HTTPStatus.OK)
+
+
+def get_sdk_version():
+    return pkg_resources.get_distribution("nuclio_sdk").version

--- a/hack/ci_assets/function/main.py
+++ b/hack/ci_assets/function/main.py
@@ -1,0 +1,25 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import http
+
+import nuclio_sdk
+
+
+def handler(context: nuclio_sdk.Context, event: nuclio_sdk.Event):
+    context.logger.debug_with("Received request", event=event.to_json())
+    return context.Response(headers=event.headers,
+                            body=event.body,
+                            content_type=event.content_type,
+                            status_code=http.HTTPStatus.OK)


### PR DESCRIPTION
Upon PR / Push, a workflow matrix of python runtimes 3.6, 3.7, 3.8 would be used to build nuclio python function
and install nuclio sdk py source code from the PR / pushed branch.