### PR TITLE
CI: followup release job fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,5 +65,5 @@ jobs:
         if: env.RC_RELEASE == 'false'
         with:
           user: __token__
-          password: ${{ secrets.DUMMY_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
Mistakenly left on DUMMY token (used for testings)

followups #25 