### PR TITLE
Introduce explicit ack methods

### DIFF
--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -229,7 +229,7 @@ class Event(object):
         Return json of offset data
         """
         return {
-            "kind": "ack",
+            "kind": "streamMessageAck",
             "attributes": {
                 "topic": self.path,
                 "partition": self.shard_id,

--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -234,7 +234,7 @@ class Event(object):
                 "topic": self.path,
                 "partition": self.shard_id,
                 "offset": self.offset,
-                "trigger_name": self.trigger.name,
+                "triggerName": self.trigger.name,
             },
         }
 

--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -224,7 +224,7 @@ class Event(object):
         """
         return kind.value.deserialize(data)
 
-    def get_explicit_ack_message(self):
+    def compile_explicit_ack_message(self):
         """
         Return json of offset data
         """

--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -224,5 +224,16 @@ class Event(object):
         """
         return kind.value.deserialize(data)
 
+    def get_explicit_ack_message(self):
+        """
+        Return json of offset data
+        """
+        return {
+            "topic": self.path,
+            "partition": self.shard_id,
+            "offset": self.offset,
+            "trigger_name": self.trigger.name,
+        }
+
     def __repr__(self):
         return self.to_json()

--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -229,10 +229,13 @@ class Event(object):
         Return json of offset data
         """
         return {
-            "topic": self.path,
-            "partition": self.shard_id,
-            "offset": self.offset,
-            "trigger_name": self.trigger.name,
+            "kind": "ack",
+            "attributes": {
+                "topic": self.path,
+                "partition": self.shard_id,
+                "offset": self.offset,
+                "trigger_name": self.trigger.name,
+            },
         }
 
     def __repr__(self):

--- a/nuclio_sdk/logger.py
+++ b/nuclio_sdk/logger.py
@@ -64,10 +64,6 @@ class Logger(object):
 
         # check if there's a handler by this name
         if handler_name in self._handlers:
-
-            # log that we're removing it
-            self.info_with("Replacing logger output", handler_name=handler_name)
-
             self._logger.removeHandler(self._handlers[handler_name])
 
         # create a stream handler from the file

--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -38,10 +38,10 @@ class Platform(object):
 
     async def explicit_ack(self, event):
         """
-        Ensures marking the offset on the stream according to the given arguments
+        Notifying the processor to ack a stream message
 
         :param event
-        :type Event
+        :type event
         """
         message = event.compile_explicit_ack_message()
         if self._control_callback:
@@ -53,8 +53,7 @@ class Platform(object):
 
     def on_signal(self, callback, sig=signal.SIGTERM):
         """
-        Registers the callback to signal.
-        this function should be called from init_context.
+        Syntactic sugar to bind an incoming system signal on user's callback
         """
         signal.signal(sig, callback)
 

--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import signal
 import http.client
 
 import nuclio_sdk
@@ -50,9 +51,12 @@ class Platform(object):
                 "Cannot send explicit ack since control callback was not initialized"
             )
 
-    async def on_abort(self, callback=None):
-        if callback is not None:
-            callback()
+    def on_signal(self, callback, sig=signal.SIGTERM):
+        """
+        Registers the callback to signal.
+        this function should be called from init_context.
+        """
+        signal.signal(sig, callback)
 
     def call_function(
         self, function_name, event, node=None, timeout=None, service_name_override=None

--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -20,7 +20,9 @@ import nuclio_sdk.helpers
 
 
 class Platform(object):
-    def __init__(self, kind, namespace="default", connection_provider=None, control_callback=None):
+    def __init__(
+        self, kind, namespace="default", connection_provider=None, control_callback=None
+    ):
         self.kind = kind
         self.namespace = namespace
 
@@ -29,21 +31,14 @@ class Platform(object):
 
         self.control_callback = control_callback
 
-    async def ensure_explicit_ack(self, topic, partition, offset, trigger_name):
+    async def ensure_explicit_ack(self, event):
         """
         Ensures marking the offset on the stream according to the given arguments
 
-        :param topic [string]
-        :param partition [int]
-        :param offset [int]
-        :param trigger_name [string]
+        :param event
+        :type event
         """
-        message = {
-            "topic": topic,
-            "partition": partition,
-            "offset": offset,
-            "trigger_name": trigger_name,
-        }
+        message = event.get_explicit_ack_message()
         await self.control_callback(message)
 
     def on_abort(self, callback=None):

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -29,6 +29,12 @@ class Response(object):
         args = ("{}={!r}".format(key, value) for key, value in items)
         return "{}({})".format(cls, ", ".join(args))
 
+    def ensure_no_ack(self):
+        """
+        ensures that offset is not marked on stream
+        """
+        self.headers["x-nuclio-stream-no-ack"] = True
+
     @staticmethod
     def from_entrypoint_output(json_encoder, handler_output):
         """Given a handler output's type, generates a response towards the

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -37,8 +37,10 @@ class Response(object):
 
     @staticmethod
     def from_entrypoint_output(json_encoder, handler_output):
-        """Given a handler output's type, generates a response towards the
-        processor"""
+        """
+        Given a handler output's type, generates a response towards the
+        processor
+        """
 
         response = Response.empty_response()
 


### PR DESCRIPTION
When working with stream triggers, allow users to ensure explicit ack when calling `explicit_ack`.
`explicit_ack` will take fields from the event object that are relevant to marking the offset on the stream, and send them as a message back to the Nuclio processor via the control socket. 

When the user-code can handle multiple events, we can ensure no-ack (meaning, to not mark the offset on the stream when receiving events) by responding on the event with a `x-nuclio-stream-no-ack` header. This way the Nuclio processor will know not to mark the offset on the stream.

Also, add `on_signal` method that will run a callback when the wrapper worker receives a SIGTERM - when a rebalance is about to happen. 

**NOTE**:
In order to `no-ack` on events, the user-code must return a (nuclio) Response object with a `x-nuclio-stream-no-ack` header (can be added by calling the response's `ensure_no_ack()` method).


Read more about the design in https://confluence.iguazeng.com/display/PLAT/Stream+Triggers+-+Explicit+ACK

Related requirement: https://jira.iguazeng.com/browse/IG-18655