### PR TITLE
Add offset field to event deserializer

### DIFF
--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -60,6 +60,7 @@ class _EventDeserializer(object):
             _type=parsed_data["type"],
             type_version=parsed_data["type_version"],
             version=parsed_data["version"],
+            offset=parsed_data["offset"],
         )
 
     @staticmethod
@@ -84,6 +85,7 @@ class _EventDeserializer(object):
             _type=parsed_data[b"type"],
             type_version=parsed_data[b"type_version"],
             version=parsed_data[b"version"],
+            offset=parsed_data[b"offset"],
         )
 
 

--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -60,7 +60,7 @@ class _EventDeserializer(object):
             _type=parsed_data["type"],
             type_version=parsed_data["type_version"],
             version=parsed_data["version"],
-            offset=parsed_data["offset"],
+            offset=parsed_data.get("offset", 0),
         )
 
     @staticmethod
@@ -85,7 +85,7 @@ class _EventDeserializer(object):
             _type=parsed_data[b"type"],
             type_version=parsed_data[b"type_version"],
             version=parsed_data[b"version"],
-            offset=parsed_data[b"offset"],
+            offset=parsed_data.get(b"offset", 0),
         )
 
 


### PR DESCRIPTION
An event's offset is used for committing records on a stream, specifically in an explicit ack (see for example `QualifiedOffset.from_event()`).
This offset was skipped when encoding / decoding an event using Msgpack.

In this PR I add `offset` support to the event deserializer.