### PR TITLE
Platform - On termination callback

### DIFF
--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -51,20 +51,21 @@ class Platform(object):
                 "Cannot send explicit ack since control callback was not initialized"
             )
 
-    def on_signal(self):
-        """
-        When a signal is received, call the termination callback as a hook before exiting
-        """
-        if self._termination_callback:
-            self._termination_callback()
-
-    def on_termination(self, callback):
+    def set_termination_callback(self, callback):
         """
         Register a callback to be called when the platform is terminating
 
         :param callback: the callback to call when terminating
         """
         self._termination_callback = callback
+
+    def on_signal(self):
+        """
+        When a signal is received, call the termination callback as a hook before exiting
+        If not set, the callback will be a no-op
+        """
+        if self._termination_callback:
+            self._termination_callback()
 
     def call_function(
         self, function_name, event, node=None, timeout=None, service_name_override=None

--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -59,14 +59,6 @@ class Platform(object):
         """
         self._termination_callback = callback
 
-    def on_signal(self):
-        """
-        When a signal is received, call the termination callback as a hook before exiting
-        If not set, the callback will be a no-op
-        """
-        if self._termination_callback:
-            self._termination_callback()
-
     def call_function(
         self, function_name, event, node=None, timeout=None, service_name_override=None
     ):
@@ -139,3 +131,11 @@ class Platform(object):
         else:
             service_name = service_name_override or "nuclio-{0}".format(function_name)
         return "{0}:8080".format(service_name)
+
+    def _on_signal(self):
+        """
+        When a signal is received, call the termination callback as a hook before exiting
+        If not set, the callback will be a no-op
+        """
+        if self._termination_callback:
+            self._termination_callback()

--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -53,7 +53,9 @@ class Platform(object):
 
     def set_termination_callback(self, callback):
         """
-        Register a callback to be called when the platform is terminating
+        Register a callback to be called when the platform is terminating.
+        If already registered, the callback will be replaced.
+        When called, the callback will be called with zero arguments.
 
         :param callback: the callback to call when terminating
         """


### PR DESCRIPTION
Allow registering a callback to be run as a hook before the function is terminating.

The nuclio wrapper will register the platform's `on_signal` to the termination signal.
If the platform's `self._termination_callback` is set, it will run before being terminated.

To set the `_termination_callback`, the user can use the following with its own `callback` function:
```
context.platform.on_termination(callback)
```