### PR TITLE
Event - serialize non-serializable fields as str

### DIFF
--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -196,7 +196,7 @@ class Event(object):
         if isinstance(obj["body"], bytes):
             obj["body"] = base64.b64encode(obj["body"]).decode("ascii")
 
-        return json.dumps(obj)
+        return json.dumps(obj, default=str)
 
     def get_header(self, header_key):
         for key, value in self.headers.items():

--- a/nuclio_sdk/test/test_event.py
+++ b/nuclio_sdk/test/test_event.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import datetime
 import json
 
 import nuclio_sdk.test
@@ -48,6 +48,14 @@ class TestEvent:
         event = nuclio_sdk.Event(body=request_body)
         serialized_event = self._deserialize_event(event)
         self.assertEqual(request_body, serialized_event.body)
+
+    def test_print_event(self):
+        """
+        Test that printing an event doesn't raise an exception
+        We don't care about the output, just that it doesn't raise an exception
+        """
+        event = nuclio_sdk.Event(body=datetime.datetime(2022, 1, 1))
+        print(event)
 
     def _deserialize_event(self, event):
         raise NotImplementedError

--- a/nuclio_sdk/test/test_event.py
+++ b/nuclio_sdk/test/test_event.py
@@ -52,7 +52,6 @@ class TestEvent:
     def test_print_event(self):
         """
         Test that printing an event doesn't raise an exception
-        We don't care about the output, just that it doesn't raise an exception
         """
         event = nuclio_sdk.Event(body=datetime.datetime(2022, 1, 1))
         print(event)


### PR DESCRIPTION
When serializing an event to json, use `str` as default.

Fixes https://jira.iguazeng.com/browse/IG-21861