### PR TITLE
[Response] Ensure body is a string when encoding is `text`

### DIFF
--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -77,9 +77,7 @@ class Response(object):
         else:
             response["body"] = handler_output
 
-        if isinstance(response["body"], bytes):
-            response["body"] = base64.b64encode(response["body"]).decode("ascii")
-            response["body_encoding"] = "base64"
+        Response._ensure_str_body(response)
 
         return response
 
@@ -92,3 +90,12 @@ class Response(object):
             "status_code": 200,
             "body_encoding": "text",
         }
+
+    @staticmethod
+    def _ensure_str_body(response):
+        if isinstance(response["body"], bytes):
+            response["body"] = base64.b64encode(response["body"]).decode("ascii")
+            response["body_encoding"] = "base64"
+
+        if response["body_encoding"] == "text":
+            response["body"] = str(response["body"])

--- a/nuclio_sdk/test/test_response.py
+++ b/nuclio_sdk/test/test_response.py
@@ -30,7 +30,12 @@ class TestResponse(nuclio_sdk.test.TestCase):
 
     def test_int(self):
         handler_return = 2020
-        expected_response = self._compile_output_response(body=2020)
+        expected_response = self._compile_output_response(body="2020")
+        self._validate_response(handler_return, expected_response)
+
+    def test_float(self):
+        handler_return = 12.34
+        expected_response = self._compile_output_response(body="12.34")
         self._validate_response(handler_return, expected_response)
 
     def test_bytes(self):
@@ -56,7 +61,7 @@ class TestResponse(nuclio_sdk.test.TestCase):
 
     def test_datetime(self):
         handler_return = datetime.datetime.now()
-        expected_response = self._compile_output_response(body=handler_return)
+        expected_response = self._compile_output_response(body=str(handler_return))
         self._validate_response(handler_return, expected_response)
 
     def test_status_code_and_str(self):


### PR DESCRIPTION
When the handler return value doesn't fall under any condition (not dict/list/`Response`) it is returned as is, causing Nuclio to fail decoding it, as it expects a string response body.

In this PR we ensure the response body is a string, unless the encoding is set otherwise.

Resolves https://jira.iguazeng.com/browse/IG-21911 