### PR TITLE
[Platform] Add drain callback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ def get_version():
         version = f.read().strip()
     if version.startswith("v"):
         version = version[1:]
+    if version == "":
+        return "0.0.0-dev0"
     return version
 
 


### PR DESCRIPTION
Currently a user can set a termination callback, which the processor invokes right before terminating.
An option to set a new callback for draining, which will be invoked on rebalancing, is needed.

The functionality is the same as the termination callback - user can set a drain callback using `set_drain_callback(callback)` in the Platform class.

Also, an argument `callback_type` was added to `_on_signal` so that the platform will know which callback to invoke - the termination callback or the drain callback.

https://jira.iguazeng.com/browse/NUC-108