### PR TITLE
[Platform] Return result of drain and termination callbacks

### DIFF
--- a/nuclio_sdk/platform.py
+++ b/nuclio_sdk/platform.py
@@ -151,6 +151,6 @@ class Platform(object):
         :arg callback_type:str - callback type, can be "termination" or "drain"
         """
         if callback_type == "termination" and self._termination_callback:
-            self._termination_callback()
+            return self._termination_callback()
         elif callback_type == "drain" and self._drain_callback:
-            self._drain_callback()
+            return self._drain_callback()


### PR DESCRIPTION
If a callback is a coroutine, returning it will allow the nuclio wrapper to await on it (as in https://github.com/nuclio/nuclio/pull/3119)