### PR TITLE
[Event] Add topic property

### DIFF
--- a/nuclio_sdk/event.py
+++ b/nuclio_sdk/event.py
@@ -61,6 +61,7 @@ class _EventDeserializer(object):
             type_version=parsed_data["type_version"],
             version=parsed_data["version"],
             offset=parsed_data.get("offset", 0),
+            topic=parsed_data.get("topic"),
         )
 
     @staticmethod
@@ -86,6 +87,7 @@ class _EventDeserializer(object):
             type_version=parsed_data[b"type_version"],
             version=parsed_data[b"version"],
             offset=parsed_data.get(b"offset", 0),
+            topic=parsed_data.get(b"topic"),
         )
 
 
@@ -162,6 +164,7 @@ class Event(object):
         version=None,
         last_in_batch=None,
         offset=None,
+        topic=None,
     ):
         self.body = body
         self.content_type = content_type
@@ -181,6 +184,7 @@ class Event(object):
         self.version = version
         self.last_in_batch = last_in_batch or False
         self.offset = offset or 0
+        self.topic = topic
 
     def to_json(self):
         obj = {}

--- a/nuclio_sdk/test/test_event.py
+++ b/nuclio_sdk/test/test_event.py
@@ -35,7 +35,7 @@ class TestEvent:
             serialized_event.trigger.__dict__,
             {"kind": "http", "name": "my-http-trigger"},
         )
-        self.assertFalse(serialized_event.last_in_batch, False)
+        self.assertFalse(serialized_event.last_in_batch)
         self.assertEqual(serialized_event.offset, 0)
 
     def test_event_to_json_bytes_non_utf8able_body(self):

--- a/nuclio_sdk/test/test_event.py
+++ b/nuclio_sdk/test/test_event.py
@@ -35,7 +35,7 @@ class TestEvent:
             serialized_event.trigger.__dict__,
             {"kind": "http", "name": "my-http-trigger"},
         )
-        self.assertEqual(serialized_event.last_in_batch, False)
+        self.assertFalse(serialized_event.last_in_batch, False)
         self.assertEqual(serialized_event.offset, 0)
 
     def test_event_to_json_bytes_non_utf8able_body(self):
@@ -45,9 +45,11 @@ class TestEvent:
 
     def test_event_to_json_string_body(self):
         request_body = "str-body"
-        event = nuclio_sdk.Event(body=request_body)
+        topic = "my-topic"
+        event = nuclio_sdk.Event(body=request_body, topic=topic)
         serialized_event = self._deserialize_event(event)
         self.assertEqual(request_body, serialized_event.body)
+        self.assertEqual(topic, serialized_event.topic)
 
     def test_print_event(self):
         """


### PR DESCRIPTION
Stream triggers use `event.path` as the topic name.
This causes some confusion for users, so adding a specific `topic` property to the event object.

Part of https://jira.iguazeng.com/browse/NUC-18