### PR TITLE
Add event_id to Response object

### DIFF
--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -17,11 +17,14 @@ import json
 
 
 class Response(object):
-    def __init__(self, headers=None, body=None, content_type=None, status_code=200):
+    def __init__(self, headers=None, body=None, content_type=None, status_code=200, event_id=None):
         self.headers = headers or {}
         self.body = body
         self.status_code = status_code
         self.content_type = content_type or "text/plain"
+
+        # id of event, it needs to be set for event batching
+        self.event_id = event_id
 
     def __repr__(self):
         cls = self.__class__.__name__
@@ -71,7 +74,8 @@ class Response(object):
             else:
                 response["body"] = handler_output.body
                 response["content_type"] = handler_output.content_type
-
+            if handler_output.event_id:
+                response["event_id"] = handler_output.event_id
             response["headers"] = handler_output.headers
             response["status_code"] = handler_output.status_code
         else:

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -17,7 +17,9 @@ import json
 
 
 class Response(object):
-    def __init__(self, headers=None, body=None, content_type=None, status_code=200, event_id=None):
+    def __init__(
+        self, headers=None, body=None, content_type=None, status_code=200, event_id=None
+    ):
         self.headers = headers or {}
         self.body = body
         self.status_code = status_code

--- a/nuclio_sdk/test/test_response.py
+++ b/nuclio_sdk/test/test_response.py
@@ -92,6 +92,11 @@ class TestResponse(nuclio_sdk.test.TestCase):
         )
         self._validate_response(handler_return, expected_response)
 
+    def test_response_with_event_id(self):
+        handler_return = nuclio_sdk.Response(body="test", event_id="1337")
+        expected_response = self._compile_output_response(body="test", event_id="1337")
+        self._validate_response(handler_return, expected_response)
+
     def _validate_response(self, handler_return, expected_response):
         response = nuclio_sdk.Response.from_entrypoint_output(
             self._encoder.encode, handler_return


### PR DESCRIPTION
Since batching feature is coming, we need to add `event_id` attribute to Response object since we will return not a single response, but the list of responses. So, we will need to match each response with sent event in order to return correct response to each user.

Jira - https://iguazio.atlassian.net/browse/NUC-155