### PR TITLE
Fix `QualifiedOffset.from_event`

### DIFF
--- a/nuclio_sdk/qualified_offset.py
+++ b/nuclio_sdk/qualified_offset.py
@@ -21,7 +21,9 @@ class QualifiedOffset(object):
 
     @staticmethod
     def from_event(event):
-        return QualifiedOffset(evnt.topic, event.shard_id, event.offset)
+        # topic resolving required to keep BC (NUC-233)
+        topic = event.topic if event.topic else event.path
+        return QualifiedOffset(topic, event.shard_id, event.offset)
 
     def compile_explicit_ack_message(self):
         """

--- a/nuclio_sdk/qualified_offset.py
+++ b/nuclio_sdk/qualified_offset.py
@@ -21,7 +21,7 @@ class QualifiedOffset(object):
 
     @staticmethod
     def from_event(event):
-        return QualifiedOffset(event.path, event.shard_id, event.offset)
+        return QualifiedOffset(evnt.topic, event.shard_id, event.offset)
 
     def compile_explicit_ack_message(self):
         """

--- a/nuclio_sdk/test/test_qualified_offset.py
+++ b/nuclio_sdk/test/test_qualified_offset.py
@@ -37,6 +37,13 @@ class TestQualifiedOffset(nuclio_sdk.test.TestCase):
         actual_explicit_ack_message = qualified_offset.compile_explicit_ack_message()
         self.assertEqual(expected_explicit_ack_message, actual_explicit_ack_message)
 
+        # check that if topic is passed, it takes precedence
+        event.topic = "topic"
+        expected_explicit_ack_message["attributes"]["topic"] = "topic"
+        qualified_offset = nuclio_sdk.QualifiedOffset.from_event(event)
+        actual_explicit_ack_message = qualified_offset.compile_explicit_ack_message()
+        self.assertEqual(expected_explicit_ack_message, actual_explicit_ack_message)
+
     def _check_equal_qualified_offsets(self, expected, actual):
         self.assertEqual(expected.topic, actual.topic)
         self.assertEqual(expected.partition, actual.partition)


### PR DESCRIPTION
jira - https://iguazio.atlassian.net/browse/NUC-267

This PR partly changes back the changes done in https://github.com/nuclio/nuclio-sdk-py/pull/46/files, because in the latest nuclio versions v3io stream's path is in `event.topic`, not in `event.path` as it used to be before. In order to support both older and newer versions, resolving logic has been added which will take path value if topic isn't passed.