### PR TITLE
[CI] Bump python version to 3.9 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 env:
-  PIPENV_PYTHON_VERSION: 3.7
+  PIPENV_PYTHON_VERSION: 3.9
 
 jobs:
   build-and-release:


### PR DESCRIPTION
3.7 isn't supported anymore. Thus, aligning the CI.