### PR TITLE
[CI] Bump actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
         with:
           go-version: "^1.21.0"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/nuclio/go.sum') }}


### PR DESCRIPTION
Version 2 of actions/cache is deprecated, so bumping it to v4.