### PR TITLE
[Streaming] Support body as generator object

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ bleach = "==3.3.0"
 black = "==24.3.0"
 importlib_metadata = "<3"
 build = ">0.2"
+pytest-asyncio = "==0.23.5"
 
 [scripts]
 fmt = "black ."

--- a/nuclio_sdk/__init__.py
+++ b/nuclio_sdk/__init__.py
@@ -16,6 +16,11 @@ from nuclio_sdk.logger import Logger
 from nuclio_sdk.context import Context
 from nuclio_sdk.event import Event, TriggerInfo, EventDeserializerKinds
 from nuclio_sdk.platform import Platform
-from nuclio_sdk.response import Response
+from nuclio_sdk.response import (
+    Response,
+    GENERATOR_RESPONSE,
+    SINGLE_RESPONSE,
+    RESPONSE_WITH_GENERATOR_BODY,
+)
 from nuclio_sdk.exceptions import ExceptionWithResponse
 from nuclio_sdk.qualified_offset import QualifiedOffset

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -14,6 +14,12 @@
 
 import base64
 import json
+import types
+import typing
+
+SINGLE_RESPONSE = "single"
+GENERATOR_RESPONSE = "generator"
+RESPONSE_WITH_GENERATOR_BODY = "response_with_generator_body"
 
 
 class Response(object):
@@ -41,12 +47,67 @@ class Response(object):
         self.headers["x-nuclio-stream-no-ack"] = True
 
     @staticmethod
+    async def from_entrypoint_output_async(json_encoder, handler_output):
+
+        handler_output_type = Response.get_handler_output_type(handler_output)
+        # Support streaming via sync or async generator
+        if handler_output_type == GENERATOR_RESPONSE:
+            async for chunk in Response.from_generator_output(
+                json_encoder, handler_output
+            ):
+                yield chunk
+
+        # If the handler output is a Response object with a generator body
+        elif handler_output_type == RESPONSE_WITH_GENERATOR_BODY:
+            async for chunk in Response.from_generator_output(
+                json_encoder, handler_output.body
+            ):
+                yield chunk
+
+        else:
+            yield Response.from_entrypoint_output(json_encoder, handler_output)
+
+    @staticmethod
+    def get_handler_output_type(handler_output):
+        if isinstance(handler_output, (types.AsyncGeneratorType, types.GeneratorType)):
+            return GENERATOR_RESPONSE
+        if isinstance(handler_output, Response) and isinstance(
+            handler_output.body, (types.AsyncGeneratorType, types.GeneratorType)
+        ):
+            return RESPONSE_WITH_GENERATOR_BODY
+        return SINGLE_RESPONSE
+
+    @staticmethod
+    async def from_generator_output(json_encoder, generator):
+        first = True
+        async_gen = (
+            generator
+            if isinstance(generator, types.AsyncGeneratorType)
+            else _sync_to_async_gen(generator)
+        )
+
+        async for item in async_gen:
+            if first:
+                first = False
+                # Use regular response logic for the first item only
+                # so it includes headers, status code, etc.
+                response = Response.from_entrypoint_output(json_encoder, item)
+                yield response
+            else:
+                # All subsequent outputs are base64-encoded raw bodies
+                # extract response body if it's a Response object
+                raw = item.body if isinstance(item, Response) else item
+                encoded = base64.b64encode(
+                    raw.encode() if isinstance(raw, str) else raw
+                ).decode("ascii")
+                yield encoded
+
+    @staticmethod
     def from_entrypoint_output(json_encoder, handler_output):
         """
         Given a handler output's type, generates a response towards the
         processor
         """
-
         response = Response.empty_response()
 
         # if the type of the output is a string, just return that and 200
@@ -105,3 +166,9 @@ class Response(object):
 
         if response["body_encoding"] == "text":
             response["body"] = str(response["body"])
+
+
+async def _sync_to_async_gen(sync_gen):
+    # Helper to convert sync generator to async generator
+    for item in sync_gen:
+        yield item

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -49,20 +49,17 @@ class Response(object):
     async def from_entrypoint_output_async(json_encoder, handler_output):
 
         handler_output_type = Response.get_handler_output_type(handler_output)
-        # Support streaming via sync or async generator
-        if handler_output_type == GENERATOR_RESPONSE:
+
+        if handler_output_type in [GENERATOR_RESPONSE, RESPONSE_WITH_GENERATOR_BODY]:
+            response_output = (
+                handler_output.body
+                if handler_output_type == RESPONSE_WITH_GENERATOR_BODY
+                else handler_output
+            )
             async for chunk in Response.from_generator_output(
-                json_encoder, handler_output
+                json_encoder, response_output
             ):
                 yield chunk
-
-        # If the handler output is a Response object with a generator body
-        elif handler_output_type == RESPONSE_WITH_GENERATOR_BODY:
-            async for chunk in Response.from_generator_output(
-                json_encoder, handler_output.body
-            ):
-                yield chunk
-
         else:
             yield Response.from_entrypoint_output(json_encoder, handler_output)
 

--- a/nuclio_sdk/response.py
+++ b/nuclio_sdk/response.py
@@ -15,7 +15,6 @@
 import base64
 import json
 import types
-import typing
 
 SINGLE_RESPONSE = "single"
 GENERATOR_RESPONSE = "generator"

--- a/nuclio_sdk/test/test_streaming.py
+++ b/nuclio_sdk/test/test_streaming.py
@@ -85,15 +85,12 @@ def test_get_handler_output_type(use_async):
     assert Response.get_handler_output_type(gen) == GENERATOR_RESPONSE
 
     # Case 2: handler_output is a Response with generator body
-    resp_with_gen_body = Response(body=gen)
-    assert (
-        Response.get_handler_output_type(resp_with_gen_body)
-        == RESPONSE_WITH_GENERATOR_BODY
-    )
+    response = Response(body=gen)
+    assert Response.get_handler_output_type(response) == RESPONSE_WITH_GENERATOR_BODY
 
     # Case 3: handler_output is a plain Response with non-generator body
-    resp_plain = Response(body="non-generator body")
-    assert Response.get_handler_output_type(resp_plain) == SINGLE_RESPONSE
+    response = Response(body="non-generator body")
+    assert Response.get_handler_output_type(response) == SINGLE_RESPONSE
 
     # Case 4: handler_output is something else (e.g., string)
     assert Response.get_handler_output_type("hello") == SINGLE_RESPONSE

--- a/nuclio_sdk/test/test_streaming.py
+++ b/nuclio_sdk/test/test_streaming.py
@@ -1,0 +1,100 @@
+import base64
+import pytest
+from nuclio_sdk import (
+    Response,
+    json_encoder,
+    GENERATOR_RESPONSE,
+    RESPONSE_WITH_GENERATOR_BODY,
+    SINGLE_RESPONSE,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("yield_as_response", [False, True])
+async def test_from_entrypoint_output_async_streaming(is_async, yield_as_response):
+    def make_response(body):
+        return Response(
+            body=body,
+            content_type="text/custom",
+            status_code=206,
+            headers={"x-my-header": "test"},
+        )
+
+    # Set up sync or async generator with str, bytes, and newline-containing data
+    items = ["first", "second\nchunk", b"final bytes"]
+    values = [make_response(i) if yield_as_response else i for i in items]
+
+    if is_async:
+
+        async def gen():
+            for val in values:
+                yield val
+
+    else:
+
+        def gen():
+            for val in values:
+                yield val
+
+    generator = gen()
+    encoder = json_encoder.Encoder()
+
+    output_chunks = []
+    async for chunk in Response.from_entrypoint_output_async(encoder, generator):
+        output_chunks.append(chunk)
+
+    # First chunk should be a full response
+    first_expected_body = "first"
+    first_chunk = output_chunks[0]
+    assert isinstance(first_chunk, dict)
+    assert first_chunk["body"] == first_expected_body
+    assert first_chunk["status_code"] == (206 if yield_as_response else 200)
+    assert first_chunk["content_type"] == (
+        "text/custom" if yield_as_response else "text/plain"
+    )
+    if yield_as_response:
+        assert first_chunk["headers"]["x-my-header"] == "test"
+
+    # Remaining chunks should be base64-encoded body values
+    for i, raw in enumerate(items[1:], start=1):
+        expected_encoded = base64.b64encode(
+            raw.encode() if isinstance(raw, str) else raw
+        ).decode("ascii")
+        assert output_chunks[i] == expected_encoded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [False, True])
+def test_get_handler_output_type(use_async):
+    # Create sync or async generator
+    if use_async:
+
+        async def async_gen():
+            yield 1
+
+        gen = async_gen()
+    else:
+
+        def sync_gen():
+            yield 1
+
+        gen = sync_gen()
+
+    # Case 1: handler_output is a generator itself
+    assert Response.get_handler_output_type(gen) == GENERATOR_RESPONSE
+
+    # Case 2: handler_output is a Response with generator body
+    resp_with_gen_body = Response(body=gen)
+    assert (
+        Response.get_handler_output_type(resp_with_gen_body)
+        == RESPONSE_WITH_GENERATOR_BODY
+    )
+
+    # Case 3: handler_output is a plain Response with non-generator body
+    resp_plain = Response(body="non-generator body")
+    assert Response.get_handler_output_type(resp_plain) == SINGLE_RESPONSE
+
+    # Case 4: handler_output is something else (e.g., string)
+    assert Response.get_handler_output_type("hello") == SINGLE_RESPONSE
+    assert Response.get_handler_output_type(123) == SINGLE_RESPONSE


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-463

This change allows for nuclio side implementation of streaming responses. 

Added three types of user code output responses:
 *  `SINGLE_RESPONSE` (normal flow)
 * `GENERATOR_RESPONSE` (for the case when user want to yield in the handler itself)
 *  `RESPONSE_WITH_GENERATOR_BODY` (for the case when body is passed as generator to nuclio.Response)
 
The idea is to use `from_entrypoint_output_async` and `get_handler_output_type` in the Nuclio wrapper so that when the entrypoint returns output, we can understand the type of this output and decide how to handle it.
`from_entrypoint_output_async `is asynchronous, which allows for context switches when running in async mode.

If `handler_output` is stream, then we yield only the 1st object as json object, all following objects are just be base64 encoding of the body (without status code, handler and etc)