### PR TITLE
[CI] Adjust integration tests to reflect the updated Nuclio behavior that removes the default project

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,7 @@ jobs:
           nuctl deploy $FUNCTION_NAME \
             --verbose \
             --runtime python:${{ matrix.python_version }} \
+            --project-name default \
             --handler main:handler \
             --build-command "@nuclio.postCopy" \
             --build-command "pip install git+https://github.com/$ACTOR/nuclio-sdk-py.git@$BRANCH" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python_version: [ '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.9', '3.10', '3.11' ]
+        python_version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
@@ -161,6 +161,10 @@ jobs:
           # print version for sanity
           nuctl version
         working-directory: nuclio
+
+      - name: Create project
+        run: |
+          nuctl create project default
 
       - name: Deploy function
         run: |

--- a/hack/ci_assets/function/main.py
+++ b/hack/ci_assets/function/main.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
 import http
 import json
+from importlib.metadata import version
 
 import nuclio_sdk
 
@@ -58,7 +58,7 @@ def handler(context: nuclio_sdk.Context, event: nuclio_sdk.Event):
 
 
 def get_sdk_version():
-    return pkg_resources.get_distribution("nuclio_sdk").version
+    return version("nuclio_sdk")
 
 
 def json_default(s):


### PR DESCRIPTION
As of nuclio 1.15 the default project was deprecated, so now we need to create it explicitely